### PR TITLE
Added docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ script: "pytest"
 after_success:
   - coverage report -m
   - coveralls
+  - codecov

--- a/devops/docker/amqp/Dockerfile
+++ b/devops/docker/amqp/Dockerfile
@@ -1,0 +1,9 @@
+FROM rabbitmq:latest
+
+#COPY healthcheck.sh /usr/local/bin/
+#
+#RUN chmod +x /usr/local/bin/healthcheck.sh
+#
+#HEALTHCHECK CMD sh /usr/local/bin/healthcheck.sh
+
+EXPOSE 5672

--- a/devops/docker/amqp/healthcheck.sh
+++ b/devops/docker/amqp/healthcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eo pipefail
+
+host="$(hostname -i || echo '127.0.0.1')"
+
+if ping="$(redis-cli -h "$host" ping)" && [ "$ping" = 'PONG' ]; then
+	exit 0
+fi
+
+exit 1

--- a/devops/docker/mysql/Dockerfile
+++ b/devops/docker/mysql/Dockerfile
@@ -1,0 +1,3 @@
+FROM mysql:latest
+
+HEALTHCHECK CMD "/usr/bin/mysql --user=root --password=topsecret --execute "show databases;""

--- a/devops/docker/postgres/Dockerfile
+++ b/devops/docker/postgres/Dockerfile
@@ -1,0 +1,8 @@
+FROM postgres:9.6.5-alpine
+
+# Attention: This script is only run, when no database exists
+COPY init.sh /docker-entrypoint-initdb.d/
+
+RUN chmod +x /docker-entrypoint-initdb.d/init.sh
+
+HEALTHCHECK CMD pg_isready -U postgres

--- a/devops/docker/postgres/init.sh
+++ b/devops/docker/postgres/init.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+>&2 echo "!!! First start of Postgres  !!!"
+

--- a/devops/docker/redis/Dockerfile
+++ b/devops/docker/redis/Dockerfile
@@ -1,0 +1,9 @@
+FROM redis:3.2.10-alpine
+
+COPY healthcheck.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/healthcheck.sh
+
+HEALTHCHECK CMD sh /usr/local/bin/healthcheck.sh
+
+EXPOSE 6379

--- a/devops/docker/redis/healthcheck.sh
+++ b/devops/docker/redis/healthcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eo pipefail
+
+host="$(hostname -i || echo '127.0.0.1')"
+
+if ping="$(redis-cli -h "$host" ping)" && [ "$ping" = 'PONG' ]; then
+	exit 0
+fi
+
+exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,25 @@
 version: '3.2'
 
 volumes:
-  openduty_mysql_data: {}
+#  openduty_mysql_data: {}
   openduty_postgres_data: {}
   openduty_redis_data: {}
 
 services:
-  openduty-mysql:
-    container_name: openduty-mysql
-    build: ./devops/docker/mysql
-    restart: always
-    volumes:
-      - openduty_mysql_data:/var/lib/mysql
-    environment:
-      MYSQL_USER: openduty
-      MYSQL_PASSWORD: secret
-      MYSQL_DATABASE: openduty
-      MYSQL_ROOT_PASSWORD: topsecret
-    ports:
-      - 3306:3306
-    command: --default-authentication-plugin=mysql_native_password
+#  openduty-mysql:
+#    container_name: openduty-mysql
+#    build: ./devops/docker/mysql
+#    restart: always
+#    volumes:
+#      - openduty_mysql_data:/var/lib/mysql
+#    environment:
+#      MYSQL_USER: openduty
+#      MYSQL_PASSWORD: secret
+#      MYSQL_DATABASE: openduty
+#      MYSQL_ROOT_PASSWORD: topsecret
+#    ports:
+#      - 3306:3306
+#    command: --default-authentication-plugin=mysql_native_password
 
   openduty-postgres:
     container_name: openduty-postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       POSTGRES_DB: openduty
       POSTGRES_PASSWORD: secret
     ports:
-      - 5434:5432
+      - 5432:5432
     command: -c fsync=off -c synchronous_commit=off -c full_page_writes=off
 
   openduty-redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.2'
+
+volumes:
+  openduty_mysql_data: {}
+  openduty_postgres_data: {}
+  openduty_redis_data: {}
+
+services:
+  openduty-mysql:
+    container_name: openduty-mysql
+    build: ./devops/docker/mysql
+    restart: always
+    volumes:
+      - openduty_mysql_data:/var/lib/mysql
+    environment:
+      MYSQL_USER: openduty
+      MYSQL_PASSWORD: secret
+      MYSQL_DATABASE: openduty
+      MYSQL_ROOT_PASSWORD: topsecret
+    ports:
+      - 3306:3306
+    command: --default-authentication-plugin=mysql_native_password
+
+  openduty-postgres:
+    container_name: openduty-postgres
+    build: ./devops/docker/postgres
+    restart: always
+    volumes:
+      - openduty_postgres_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: openduty
+      POSTGRES_DB: openduty
+      POSTGRES_PASSWORD: secret
+    ports:
+      - 5434:5432
+    command: -c fsync=off -c synchronous_commit=off -c full_page_writes=off
+
+  openduty-redis:
+    container_name: openduty-redis
+    restart: always
+    build:
+      context: ./devops/docker/redis/
+    volumes:
+      - openduty_redis_data:/data
+    ports:
+      - 6379:6379


### PR DESCRIPTION
`docker-compose.yml` is able to create create 3 containers:
  - `mysql`
  - `postgresql`
  - `redis`


Currently `mysql` is commented out.


Just type:
`docker-compose up -d`


and you are `ON`